### PR TITLE
WIP: Troubleshoot parameter write exception

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -1,0 +1,17 @@
+FROM scottyhardy/docker-wine:2.0.1
+
+# installing python 3.7
+ARG VIRTUAL_ENV=/opt/python3
+RUN add-apt-repository ppa:deadsnakes/ppa && \
+    apt-get update && \
+    apt-get install -y make curl git unzip graphviz python3.7 python3-pip python3.7-dev python3.7-venv && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN python3.7 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+RUN which pip
+RUN pip install --upgrade pip==20.0.2 && \
+    chown -R wineuser ${VIRTUAL_ENV}
+
+COPY . /work
+RUN chown -R wineuser /work

--- a/.ci/run_tests.sh
+++ b/.ci/run_tests.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -e
+
+docker build --file .ci/Dockerfile --tag openscm-tests .
+
+docker run -it --rm -w /src -v "$(pwd):/src" openscm-tests \
+  pip install .[tests] && pytest

--- a/.ci/run_tests.sh
+++ b/.ci/run_tests.sh
@@ -4,5 +4,6 @@ set -e
 
 docker build --file .ci/Dockerfile --tag openscm-tests .
 
-docker run -it --rm -w /src -v "$(pwd):/src" openscm-tests \
-  pip install .[tests] && pytest
+docker run -it --rm -w /work \
+  openscm-tests \
+  bash -c "pip install -e .[tests,model-MAGICC6,model-MAGICC7] && pytest -x"

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+venv/
+docs/
+.pytest_cache/
+.idea/
+.github/
+venv/
+*.egg-info
+*.egg/
+*.pyc
+*.swp
+__pycache__

--- a/openscm/adapters/ph99.py
+++ b/openscm/adapters/ph99.py
@@ -5,7 +5,7 @@ import warnings
 from typing import TYPE_CHECKING, Dict, Sequence
 
 import numpy as np
-from scmdata.units import _unit_registry
+from scmdata.units import unit_registry
 
 from ..core.parameters import HierarchicalName, ParameterInfo
 from ..errors import ParameterEmptyError
@@ -29,7 +29,7 @@ class PH99(AdapterConstantTimestep):
     foundations, Climatic Change, 41, 303–331, 1999.
     """
 
-    _hc_per_m2_approx = 1.34 * 10 ** 9 * _unit_registry("J / kelvin / m^2")
+    _hc_per_m2_approx = 1.34 * 10 ** 9 * unit_registry("J / kelvin / m^2")
     """Approximate heat capacity per unit area (used to estimate rf2xco2)"""
 
     _base_time = np.datetime64("1750-01-01")
@@ -125,7 +125,7 @@ class PH99(AdapterConstantTimestep):
                 warnings.warn(
                     "Rounding {} timestep to nearest integer".format(self.name)
                 )
-                value = int(mag) * _unit_registry(units)
+                value = int(mag) * unit_registry(units)
                 self.model.timestep = value
 
         self._add_parameter_view(full_name, value.magnitude, unit=str(value.units))
@@ -194,12 +194,12 @@ class PH99(AdapterConstantTimestep):
             if name[0] != self.name:
                 # emergency valve for now, must be smarter way to handle this
                 raise ValueError("How did non-PH99 parameter end up here?")
-            setattr(self.model, name[1], value * _unit_registry(para.unit))
+            setattr(self.model, name[1], value * unit_registry(para.unit))
 
     def _set_model_para_from_openscm_para(self, openscm_name, value, unit):
         model_name = self._openscm_standard_parameter_mappings[openscm_name]
         if unit is not None:
-            pv = value * _unit_registry(unit)
+            pv = value * unit_registry(unit)
         else:
             pv = value
 
@@ -220,7 +220,7 @@ class PH99(AdapterConstantTimestep):
         )
 
         mu = self._parameter_views[(self.name, "mu")]
-        mu = mu.value * _unit_registry(mu.unit)
+        mu = mu.value * unit_registry(mu.unit)
 
         alpha = mu * np.log(2) / v
         self.model.alpha = alpha
@@ -261,7 +261,7 @@ class PH99(AdapterConstantTimestep):
         v = (v - self._base_time).item().total_seconds()
         if int(v) != v:
             warnings.warn("Rounding {} time_start to nearest integer".format(self.name))
-        self.model.time_start = int(v) * _unit_registry("s")
+        self.model.time_start = int(v) * unit_registry("s")
 
     @property
     def timestep(self) -> np.timedelta64:

--- a/openscm/core/parameters.py
+++ b/openscm/core/parameters.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Dict, Optional, Sequence, Tuple, Union
 
 import numpy as np
 from pint import UndefinedUnitError
-from scmdata.units import _unit_registry
+from scmdata.units import unit_registry
 
 from ..errors import (
     ParameterAggregationError,
@@ -456,7 +456,7 @@ def guess_parameter_type(variable_name: str, unit: Optional[str]) -> ParameterTy
     if unit:
         # try and determine if the unit contains a time dimension
         try:
-            pint_unit = _unit_registry(unit).units
+            pint_unit = unit_registry(unit).units
             if "[time]" in str(pint_unit.dimensionality):
                 return ParameterType.AVERAGE_TIMESERIES
 

--- a/openscm/models/ph99.py
+++ b/openscm/models/ph99.py
@@ -20,7 +20,7 @@ import copy
 from typing import Any
 
 import numpy as np
-from scmdata.units import _unit_registry
+from scmdata.units import unit_registry
 
 from ..errors import OutOfBoundsError, OverwriteError
 
@@ -30,10 +30,10 @@ class PH99Model:  # pylint: disable=too-many-instance-attributes
     Implementation of model first presented in Petschel-Held Climatic Change 1999
     """
 
-    _yr = 1 * _unit_registry("yr")
+    _yr = 1 * unit_registry("yr")
     """:obj:`pint.Quantity`: one year"""
 
-    def __init__(self, time_start=0 * _unit_registry("yr")):
+    def __init__(self, time_start=0 * unit_registry("yr")):
         """
         Initialise an instance of PH99Model
 
@@ -58,7 +58,7 @@ class PH99Model:  # pylint: disable=too-many-instance-attributes
         self._check_is_pint_quantity(value)
         self._timestep = value.to(self._timestep_units).magnitude
 
-    _timestep_units = _unit_registry("yr")
+    _timestep_units = unit_registry("yr")
     _timestep = _yr.to(_timestep_units).magnitude
 
     @property
@@ -102,7 +102,7 @@ class PH99Model:  # pylint: disable=too-many-instance-attributes
         self._emissions = value.to(self._emissions_units).magnitude
         self._emissions_nan = np.isnan(np.sum(self._emissions))
 
-    _emissions_units = _unit_registry("GtC / yr")
+    _emissions_units = unit_registry("GtC / yr")
     _emissions = np.array([np.nan])
     _emissions_nan = True
 
@@ -120,7 +120,7 @@ class PH99Model:  # pylint: disable=too-many-instance-attributes
             self._cumulative_emissions_units
         ).magnitude
 
-    _cumulative_emissions_units = _unit_registry("GtC")
+    _cumulative_emissions_units = unit_registry("GtC")
     _cumulative_emissions = np.array([np.nan])
 
     @property
@@ -135,7 +135,7 @@ class PH99Model:  # pylint: disable=too-many-instance-attributes
         self._check_is_pint_quantity(value)
         self._concentrations = value.to(self._concentrations_units).magnitude
 
-    _concentrations_units = _unit_registry("ppm")
+    _concentrations_units = unit_registry("ppm")
     _concentrations = np.array([np.nan])
 
     @property
@@ -156,7 +156,7 @@ class PH99Model:  # pylint: disable=too-many-instance-attributes
     @property
     def temperatures(self):
         """`pint.Quantity` array: Global-mean temperatures"""
-        return _unit_registry.Quantity(
+        return unit_registry.Quantity(
             self._temperatures, str(self._temperatures_units)
         )
 
@@ -166,7 +166,7 @@ class PH99Model:  # pylint: disable=too-many-instance-attributes
         self._temperatures = value.to(self._temperatures_units).magnitude
 
     # have to initialise like this to avoid ambiguity...
-    _temperatures_tmp = _unit_registry.Quantity(np.array([np.nan]), "delta_degC")
+    _temperatures_tmp = unit_registry.Quantity(np.array([np.nan]), "delta_degC")
     _temperatures_units = _temperatures_tmp.units
     _temperatures = _temperatures_tmp.magnitude
 
@@ -197,7 +197,7 @@ class PH99Model:  # pylint: disable=too-many-instance-attributes
         self._check_is_pint_quantity(value)
         self._b = value.to(self._b_units).magnitude
 
-    _b_units = _unit_registry("ppm / (GtC * yr)")
+    _b_units = unit_registry("ppm / (GtC * yr)")
     _b = 1.51 * 10 ** -3
 
     @property
@@ -214,7 +214,7 @@ class PH99Model:  # pylint: disable=too-many-instance-attributes
         self._check_is_pint_quantity(value)
         self._beta = value.to(self._beta_units).magnitude
 
-    _beta_units = _unit_registry("ppm/GtC")
+    _beta_units = unit_registry("ppm/GtC")
     _beta = 0.47
 
     @property
@@ -231,7 +231,7 @@ class PH99Model:  # pylint: disable=too-many-instance-attributes
         self._check_is_pint_quantity(value)
         self._sigma = value.to(self._sigma_units).magnitude
 
-    _sigma_units = _unit_registry("1/yr")
+    _sigma_units = unit_registry("1/yr")
     _sigma = 2.15 * 10 ** -2
 
     @property
@@ -248,7 +248,7 @@ class PH99Model:  # pylint: disable=too-many-instance-attributes
         self._check_is_pint_quantity(value)
         self._c1 = value.to(self._c1_units).magnitude
 
-    _c1_units = _unit_registry("ppm")
+    _c1_units = unit_registry("ppm")
     _c1 = 290
 
     @property
@@ -268,7 +268,7 @@ class PH99Model:  # pylint: disable=too-many-instance-attributes
         self._mu = value.to(self._mu_units).magnitude
 
     # have to initialise like this to avoid ambiguity...
-    _mu_tmp = _unit_registry.Quantity(8.7 * 10 ** -2, "delta_degC/yr")
+    _mu_tmp = unit_registry.Quantity(8.7 * 10 ** -2, "delta_degC/yr")
     _mu_units = _mu_tmp.units
     _mu = _mu_tmp.magnitude
 
@@ -286,7 +286,7 @@ class PH99Model:  # pylint: disable=too-many-instance-attributes
         self._check_is_pint_quantity(value)
         self._alpha = value.to(self._alpha_units).magnitude
 
-    _alpha_units = _unit_registry("1/yr")
+    _alpha_units = unit_registry("1/yr")
     _alpha = 1.7 * 10 ** -2
 
     @property
@@ -298,7 +298,7 @@ class PH99Model:  # pylint: disable=too-many-instance-attributes
         """
         # need to better understand
         # pint.errors.OffsetUnitCalculusError: Ambiguous operation with offset unit (degC).
-        return _unit_registry.Quantity(self._t1, str(self._t1_units))
+        return unit_registry.Quantity(self._t1, str(self._t1_units))
 
     @t1.setter
     def t1(self, value):
@@ -306,7 +306,7 @@ class PH99Model:  # pylint: disable=too-many-instance-attributes
         self._t1 = value.to(self._t1_units).magnitude
 
     # have to initialise like this to avoid ambiguity...
-    _t1_tmp = _unit_registry.Quantity(14.6, "delta_degC")
+    _t1_tmp = unit_registry.Quantity(14.6, "delta_degC")
     _t1_units = _t1_tmp.units
     _t1 = _t1_tmp.magnitude
 
@@ -388,17 +388,17 @@ class PH99Model:  # pylint: disable=too-many-instance-attributes
 
         cumulative_emissions_init = copy.deepcopy(initialiser)
         cumulative_emissions_init[0] = 0
-        self.cumulative_emissions = _unit_registry.Quantity(
+        self.cumulative_emissions = unit_registry.Quantity(
             cumulative_emissions_init, "GtC"
         )
 
         concentrations_init = copy.deepcopy(initialiser)
         concentrations_init[0] = self._concentrations_t_0
-        self.concentrations = _unit_registry.Quantity(concentrations_init, "ppm")
+        self.concentrations = unit_registry.Quantity(concentrations_init, "ppm")
 
         temperatures_init = copy.deepcopy(initialiser)
         temperatures_init[0] = self._temperatures_t_0
-        self.temperatures = _unit_registry.Quantity(temperatures_init, "delta_degC")
+        self.temperatures = unit_registry.Quantity(temperatures_init, "delta_degC")
 
     def run(self) -> None:
         """

--- a/openscm/scmdataframe.py
+++ b/openscm/scmdataframe.py
@@ -23,7 +23,7 @@ from openscm.core.parameters import (
 )
 from openscm.core.parameterset import ParameterSet
 from openscm.core.time import ExtrapolationType, InterpolationType, TimeseriesConverter
-from openscm.errors import ParameterEmptyError
+from openscm.errors import ParameterEmptyError, ParameterWrittenError
 
 
 class OpenScmDataFrame(ScmDataFrame):  # type: ignore
@@ -109,13 +109,19 @@ class OpenScmDataFrame(ScmDataFrame):  # type: ignore
                 delta_t = time_points[-1] - time_points[-2]
                 time_points = np.concatenate((time_points, [time_points[-1] + delta_t]))
 
-            parameterset.timeseries(
-                variable,
-                unit,
-                time_points=time_points,
-                region=region,
-                timeseries_type=timeseries_type,
-            ).values = vals.values
+            print(f'Setting [variable={variable}, unit={unit}, region={region}]...')
+            try:
+                parameterset.timeseries(
+                    variable,
+                    unit,
+                    time_points=time_points,
+                    region=region,
+                    timeseries_type=timeseries_type,
+                ).values = vals.values
+            except ParameterWrittenError as e:
+                # hack
+                print(f'Cannot set [variable={variable}, unit={unit}, region={region}]: {str(e)}')
+                continue
 
         unit_regexp = re.compile(r".*\(.*\)")
         for k, v in meta_values.iteritems():

--- a/openscm/scmdataframe.py
+++ b/openscm/scmdataframe.py
@@ -110,18 +110,25 @@ class OpenScmDataFrame(ScmDataFrame):  # type: ignore
                 time_points = np.concatenate((time_points, [time_points[-1] + delta_t]))
 
             print(f'Setting [variable={variable}, unit={unit}, region={region}]...')
-            try:
-                parameterset.timeseries(
-                    variable,
-                    unit,
-                    time_points=time_points,
-                    region=region,
-                    timeseries_type=timeseries_type,
-                ).values = vals.values
-            except ParameterWrittenError as e:
-                # hack
-                print(f'Cannot set [variable={variable}, unit={unit}, region={region}]: {str(e)}')
-                continue
+            parameterset.timeseries(
+                variable,
+                unit,
+                time_points=time_points,
+                region=region,
+                timeseries_type=timeseries_type,
+            ).values = vals.values
+            # try:
+            #     parameterset.timeseries(
+            #         variable,
+            #         unit,
+            #         time_points=time_points,
+            #         region=region,
+            #         timeseries_type=timeseries_type,
+            #     ).values = vals.values
+            # except ParameterWrittenError as e:
+            #     # hack
+            #     print(f'Cannot set [variable={variable}, unit={unit}, region={region}]: {str(e)}')
+            #     continue
 
         unit_regexp = re.compile(r".*\(.*\)")
         for k, v in meta_values.iteritems():

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ REQUIREMENTS_INSTALL = [
     "scmdata",
     "scipy",
     "pint",
-    "pandas>=0.25",
+    "pandas<1.0",
     "python-dateutil",
     "tqdm",
 ]

--- a/setup.py
+++ b/setup.py
@@ -38,10 +38,10 @@ CLASSIFIERS = [
 ]
 REQUIREMENTS_INSTALL = [
     "numpy>=1.7",
-    "scmdata",
+    "scmdata>=0.4.0",
     "scipy",
     "pint",
-    "pandas<1.0",
+    "pandas>=1.0",
     "python-dateutil",
     "tqdm",
 ]


### PR DESCRIPTION
Hi @znicholls! We currently have an issue running climate assesment from openclimatedata/openscm (branch iiasa-climate-assesment). So I created this branch trying to figure out the source of a problem. Could you have a look on following output generated by output statements I added:
```
Setting [variable=Emissions|BC, unit=Mt BC/yr, region=World]...                                                           
Setting [variable=Emissions|C2F6, unit=kt C2F6/yr, region=World]...
Setting [variable=Emissions|C6F14, unit=kt C6F14/yr, region=World]...
Setting [variable=Emissions|CF4, unit=kt CF4/yr, region=World]...
Setting [variable=Emissions|CH4, unit=Mt CH4/yr, region=World]...
Setting [variable=Emissions|CO, unit=Mt CO/yr, region=World]...
Setting [variable=Emissions|CO2|MAGICC AFOLU, unit=Mt CO2/yr, region=World]...
Setting [variable=Emissions|CO2|MAGICC Fossil and Industrial, unit=Mt CO2/yr, region=World]...
Setting [variable=Emissions|HFC125, unit=kt HFC125/yr, region=World]...
Setting [variable=Emissions|HFC134a, unit=kt HFC134a/yr, region=World]...
Setting [variable=Emissions|HFC143a, unit=kt HFC143a/yr, region=World]...
Setting [variable=Emissions|HFC227ea, unit=kt HFC227ea/yr, region=World]...
Setting [variable=Emissions|HFC23, unit=kt HFC23/yr, region=World]...
Setting [variable=Emissions|HFC245fa, unit=kt HFC245fa/yr, region=World]...
Setting [variable=Emissions|HFC32, unit=kt HFC32/yr, region=World]...
Setting [variable=Emissions|HFC4310, unit=kt HFC4310/yr, region=World]...
Setting [variable=Emissions|N2O, unit=kt N2O/yr, region=World]...
Setting [variable=Emissions|NH3, unit=Mt NH3/yr, region=World]...
Setting [variable=Emissions|NMVOC, unit=Mt VOC/yr, region=World]...
Setting [variable=Emissions|NOx, unit=Mt N / yr, region=World]...
Setting [variable=Emissions|OC, unit=Mt OC/yr, region=World]...
Setting [variable=Emissions|SF6, unit=kt SF6/yr, region=World]...
Setting [variable=Emissions|SOx, unit=Mt SO2/yr, region=World]...
Setting [variable=Atmospheric Concentrations|CH4, unit=ppb, region=World]...
Setting [variable=Atmospheric Concentrations|CO2, unit=ppm, region=World]...
Setting [variable=Atmospheric Concentrations|N2O, unit=ppb, region=World]...
Setting [variable=Effective Radiative Forcing|CH4, unit=W / m^2, region=World]...
Setting [variable=Effective Radiative Forcing|CO2, unit=W / m^2, region=World]...
Setting [variable=Effective Radiative Forcing|N2O, unit=W / m^2, region=World]...
Setting [variable=Effective Radiative Forcing|Total, unit=W / m^2, region=World]...
Setting [variable=Emissions|BC|MAGICC AFOLU, unit=Mt BC / yr, region=World]...
Setting [variable=Emissions|BC|MAGICC Fossil and Industrial, unit=Mt BC / yr, region=World]...
Setting [variable=Emissions|CO2|MAGICC AFOLU, unit=Gt C / yr, region=World]...
Setting [variable=Emissions|CO2|MAGICC Fossil and Industrial, unit=Gt C / yr, region=World]...
Setting [variable=HEATUPTAKE_EBALANCE_TOTAL, unit=W / m^2, region=World]...
Setting [variable=Radiative Forcing|Aerosols|Direct Effect, unit=W / m^2, region=World]...
Setting [variable=Radiative Forcing|Aerosols|Direct Effect|BC|MAGICC Fossil and Industrial, unit=W / m^2, region=World]...
Cannot set [variable=Radiative Forcing|Aerosols|Direct Effect|BC|MAGICC Fossil and Industrial, unit=W / m^2, region=World]: 
Setting [variable=Radiative Forcing|Aerosols|Direct Effect|MAGICC AFOLU, unit=W / m^2, region=World]...
Cannot set [variable=Radiative Forcing|Aerosols|Direct Effect|MAGICC AFOLU, unit=W / m^2, region=World]: 
Setting [variable=Radiative Forcing|Aerosols|Direct Effect|Mineral Dust, unit=W / m^2, region=World]...
Cannot set [variable=Radiative Forcing|Aerosols|Direct Effect|Mineral Dust, unit=W / m^2, region=World]: 
Setting [variable=Radiative Forcing|Aerosols|Direct Effect|NOx|MAGICC Fossil and Industrial, unit=W / m^2, region=World]...
Cannot set [variable=Radiative Forcing|Aerosols|Direct Effect|NOx|MAGICC Fossil and Industrial, unit=W / m^2, region=World]: 
Setting [variable=Radiative Forcing|Aerosols|Direct Effect|OC|MAGICC Fossil and Industrial, unit=W / m^2, region=World]...
Cannot set [variable=Radiative Forcing|Aerosols|Direct Effect|OC|MAGICC Fossil and Industrial, unit=W / m^2, region=World]: 
Setting [variable=Radiative Forcing|Aerosols|Direct Effect|SOx|MAGICC Fossil and Industrial, unit=W / m^2, region=World]...
Cannot set [variable=Radiative Forcing|Aerosols|Direct Effect|SOx|MAGICC Fossil and Industrial, unit=W / m^2, region=World]: 
Setting [variable=Radiative Forcing|Aerosols|Indirect Effect, unit=W / m^2, region=World]...
Setting [variable=Radiative Forcing|CH4, unit=W / m^2, region=World]...
Setting [variable=Radiative Forcing|CO2, unit=W / m^2, region=World]...
Setting [variable=Radiative Forcing|N2O, unit=W / m^2, region=World]...
Setting [variable=Radiative Forcing|Total, unit=W / m^2, region=World]...
Setting [variable=Surface Temperature Increase, unit=K, region=World]...
/opt/python3/lib/python3.7/site-packages/openscm/adapters/magicc/base.py:279: UserWarning: Not returning parameters without units
  warnings.warn("Not returning parameters without units")
```
It looks property setter cannot handle the situation setting a value for varubale with higher nesting when variable with lower nesting is already set, e.g. `Radiative Forcing|Aerosols|Direct Effect|BC|MAGICC Fossil and Industrial` after `Radiative Forcing|Aerosols|Direct Effect`, in following code fragment from 'scmdataframe.py' (ParameterWrittenError is thrown):
```
                parameterset.timeseries(
                    variable,
                    unit,
                    time_points=time_points,
                    region=region,
                    timeseries_type=timeseries_type,
                ).values = vals.values
```

